### PR TITLE
Remux MKV -> MP4 with stream-copy instead of re-encoding (removes hardsubs)

### DIFF
--- a/api/src/converter.coffee
+++ b/api/src/converter.coffee
@@ -55,7 +55,7 @@ convertVideo = (fileName) ->
     inputFile = "#{path}/#{fileName}"
     outputFile = "#{path}/#{newFileName}"
 
-    # Stream-copy video and audio, remove subtitles
+    # Remux to MP4 by stream-copying video and audio, removing subtitles.
     command = "#{binExecutable} -i '#{inputFile}' -map 0:v -map 0:a -c copy -movflags +faststart -y '#{outputFile}'"
 
     log(

--- a/api/src/converter.coffee
+++ b/api/src/converter.coffee
@@ -55,8 +55,8 @@ convertVideo = (fileName) ->
     inputFile = "#{path}/#{fileName}"
     outputFile = "#{path}/#{newFileName}"
 
-    # For mp4 (with hardsub)
-    command = "#{binExecutable} -i '#{inputFile}' -filter_complex \"subtitles='#{inputFile}'\" -c:v libx264 -crf 30 -b:v 500K -c:a aac -preset:v ultrafast -y '#{outputFile}'"
+    # Stream-copy video and audio, remove subtitles
+    command = "#{binExecutable} -i '#{inputFile}' -map 0:v -map 0:a -c copy -movflags +faststart -y '#{outputFile}'"
 
     log(
       "ffmpeg"

--- a/app/src/components/episodeVideo.coffee
+++ b/app/src/components/episodeVideo.coffee
@@ -262,7 +262,7 @@ QualityButtons = ({ setQuality }) ->
   </>
 
 Main = ({ watchData }) ->
-  [quality, setQuality] = useState "480p"
+  [quality, setQuality] = useState "1080p"
 
   urlParams = new URLSearchParams window.location.search
 

--- a/app/src/components/episodeVideo.coffee
+++ b/app/src/components/episodeVideo.coffee
@@ -243,6 +243,7 @@ Video = ({ watchData, quality }) ->
     <div className="my-5">
       <video controls>
         <source src={videoData.videoFilePath} type="video/mp4" />
+        <track kind="subtitles" src={videoData.subsFilePath} srclang="en" label="English" />
       </video>
     </div>
 


### PR DESCRIPTION
Removes hardsubs in favour of faster conversion times. This remuxes MKV to MP4 using stream-copying instead of re-encoding (which was necessary to burn-in subtitles).

It looks like you intended to use the extracted WebVTT subs somehow, and I think this is what you were originally going for. The default quality has been changed to 1080p since conversion is basically instant now <- you can change this back if it was 480p for a different reason.

The subtitles look like this now.:
![2024-01-21_18 56_firefox](https://github.com/davnpsh/luffy/assets/120446961/8e510bf8-cfa2-41bd-9772-71c0af4f7d2e)
Signs that actually cover their original text will be broken (no positioning), but those are rare outside of fansubs.

But you can style them using CSS: https://developer.mozilla.org/en-US/docs/Web/CSS/::cue
Info on WebVTT: https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API
Info on `<track>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track